### PR TITLE
Convert Stimulus targets to kebab-cased

### DIFF
--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= turbo_frame_tag "new_message", target: "_top" do %>
   <%= form_with(model: [ @message.room, @message ],
-        data: { controller: "reset_form", action: "turbo:submit-end->reset_form#reset" }) do |form| %>
+        data: { controller: "reset-form", action: "turbo:submit-end->reset-form#reset" }) do |form| %>
     <div class="field">
       <%= form.text_field :content %>
       <%= form.submit "Send" %>


### PR DESCRIPTION
This PR updates the Stimulus targets to follow the naming conventions set forth in Stimulus 2.0, which are conventionally kebab-case.